### PR TITLE
Support new format for boolean parameters

### DIFF
--- a/src/capture.js
+++ b/src/capture.js
@@ -3,31 +3,26 @@
 // Licensed under the MIT License. See LICENSE file for full license information.
 //
 
-function addKeyValue(params, e) {
-  var key = e.previousElementSibling.textContent;
-  var value = null;
+function detectKey(e) {
+  return e.previousElementSibling.textContent || e.querySelector('label').textContent;
+}
 
+function detectValue(e) {
   var input = e.querySelector('input:not([type="hidden"]),textarea,select');
   switch (input.tagName.toLowerCase()) {
   case 'input':
     switch (input.type.toLowerCase()) {
     case 'checkbox':
-      value = input.checked ? 'true' : 'false';
-      break;
+      return input.checked ? 'true' : 'false';
     default:
-      value = input.value;
+      return input.value;
     }
     break;
   case 'textarea':
   case 'select':
-    value = input.value;
-    break;
+    return input.value;
   default:
-    value = '(unknown)';
-  }
-
-  if (key !== null && value !== null) {
-    params[key] = value;
+    return '(unknown)';
   }
 }
 
@@ -44,7 +39,10 @@ function capture() {
 
   var params = {};
   elements.forEach(function (e) {
-    addKeyValue(params, e);
+    var key = detectKey(e), value = detectValue(e);
+    if (key !== null && value !== null) {
+      params[key] = value;
+    }
   });
 
   var data = {


### PR DESCRIPTION
As of a new version of Jenkins (I don't know the details though), DOM structure for boolean parameters have been changed.
They have no parameter names in `.setting-name` block anymore, and the parameter names went to `label` elements appended to the checkboxes.

After applying this change, both old-styled and new-styled structures are supported.