### PR TITLE
Add extension ID

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,5 +20,10 @@
       "matches": ["<all_urls>"],
       "js": ["content.js"]
     }
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{b1e766e1-2f9b-4d1e-919a-f2f588d32050}"
+    }
+  }
 }


### PR DESCRIPTION
Mozilla requires extension ID in manifest V3.